### PR TITLE
automatically add -latomic/-lpthread if necessary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
 LinkingTo: 
     Rcpp,
     RcppEigen,
-    RcppThread
+    RcppThread (>= 2.1.3)
 Imports: 
     Rcpp, cli
 Suggests: 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,3 @@
 CXX_STD = CXX14
 PKG_CXXFLAGS = -I../inst/include -pthread
+PKG_LIBS = `"$(R_HOME)/bin/Rscript" -e "RcppThread::LdFlags()"`


### PR DESCRIPTION
This fixes the ERROR on CRAN's [r-devel-linux-x86_64-debian-clang](https://cran.rstudio.com/web/checks/check_results_rethnicity.html).  See also https://github.com/tnagler/RcppThread#in-another-r-package.